### PR TITLE
Bug fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    "version_selector": True,
+    "display_version": True,
     "prev_next_buttons_location": "bottom",
     # Toc options
     "collapse_navigation": False,


### PR DESCRIPTION
In the last version, I updated the `conf.py` for the newest standard, and it caused the `read the doc` cannot build the website.

Now I roll the `conf.py` back.